### PR TITLE
Use the value of PropertyValue.name when looking for parameters

### DIFF
--- a/algorithm/src/index.js
+++ b/algorithm/src/index.js
@@ -349,7 +349,7 @@ async function getControlActionByIdentifier(identifier) {
  * @returns {Promise}
  */
 async function getControlActionObjectValues(controlAction) {
-  const digitalDocumentPropertyValue = controlAction.object.find(({ name }) => name === 'MusicXML File');
+  const digitalDocumentPropertyValue = controlAction.object.find(({ name }) => name === 'targetFile');
   const resultNamePropertyValue = controlAction.object.find(({ name }) => name === 'resultName');
 
   const digitalDocument = digitalDocumentPropertyValue && digitalDocumentPropertyValue.nodeValue;


### PR DESCRIPTION
This is the poc-algorithm change to reflect the fix made in https://github.com/trompamusic/ce-api/pull/131

Now that PropertyValue.name is copied from Property.name, we need to check against this value instead of the value in Property.title